### PR TITLE
Feature/image recognition

### DIFF
--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -54,14 +54,18 @@ export default function CameraPage() {
 
         const result = await response.json();
 
-        // ✅ 撮影結果と画像を result ページに渡して遷移
-        const imageUrl = URL.createObjectURL(blob);
-        const query = new URLSearchParams({
-          machine: result.machine_name,
-          menus: JSON.stringify(result.menus),
-          image: imageUrl,
-        });
-        router.push(`/result?${query.toString()}`);
+        // ✅ 画像を localStorage に保存
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          localStorage.setItem('capturedImage', reader.result as string); // base64形式で保存
+
+          const query = new URLSearchParams({
+            machine: result.machine_name,
+            menus: JSON.stringify(result.menus),
+          });
+          router.push(`/result?${query.toString()}`);
+        };
+        reader.readAsDataURL(blob); // base64化
       } catch (error) {
         console.error('判別失敗:', error);
         alert('マシンの判定に失敗しました');
@@ -99,7 +103,7 @@ export default function CameraPage() {
           </button>
         )}
 
-        <canvas ref={canvasRef} className="mt-4 rounded" />
+        <canvas ref={canvasRef} className="hidden" />
       </div>
     </>
   );

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -22,54 +22,56 @@ export default function CameraPage() {
   };
 
   const handleTakePhoto = async () => {
-  if (!videoRef.current || !canvasRef.current) return;
+    if (!videoRef.current || !canvasRef.current) return;
 
-  const context = canvasRef.current.getContext('2d');
-  if (!context) return;
+    const context = canvasRef.current.getContext('2d');
+    if (!context) return;
 
-  const width = videoRef.current.videoWidth;
-  const height = videoRef.current.videoHeight;
+    const width = videoRef.current.videoWidth;
+    const height = videoRef.current.videoHeight;
 
-  canvasRef.current.width = width;
-  canvasRef.current.height = height;
-  context.drawImage(videoRef.current, 0, 0, width, height);
+    canvasRef.current.width = width;
+    canvasRef.current.height = height;
+    context.drawImage(videoRef.current, 0, 0, width, height);
 
-  // canvas → Blob に変換
-  canvasRef.current.toBlob(async (blob) => {
-    if (!blob) return;
+    // canvas → Blob に変換
+    canvasRef.current.toBlob(async (blob) => {
+      if (!blob) return;
 
-    const formData = new FormData();
-    formData.append('image', blob, 'photo.jpg');
+      const formData = new FormData();
+      formData.append('image', blob, 'photo.jpg');
 
-    try {
-      const response = await fetch('http://localhost:3000/api/v1/machines/identify', {
-        method: 'POST',
-        body: formData,
-      });
+      try {
+        const response = await fetch('http://localhost:3000/api/v1/machines/identify', {
+          method: 'POST',
+          body: formData,
+        });
 
-      if (!response.ok) {
-        throw new Error('サーバーエラー');
+        if (!response.ok) {
+          throw new Error('サーバーエラー');
+        }
+
+        const result = await response.json();
+        alert(`マシン: ${result.machine_name}\nメニュー:\n${result.menus.map((m: any) => `・${m.name} (${m.part})`).join('\n')}`);
+      } catch (error) {
+        console.error('判別失敗:', error);
+        alert('マシンの判定に失敗しました');
       }
-
-      const result = await response.json();
-      alert(`マシン: ${result.machine_name}\nメニュー:\n${result.menus.map((m: any) => `・${m.name} (${m.part})`).join('\n')}`);
-    } catch (error) {
-      console.error('判別失敗:', error);
-      alert('マシンの判定に失敗しました');
-    }
-  }, 'image/jpeg');
-};
+    }, 'image/jpeg');
+  };
 
   return (
     <>
       <Header />
       <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white p-4 gap-4">
         {!streaming && (
+
           <button
             onClick={handleStartCamera}
-            className="bg-[#B31717] text-white text-lg font-bold py-4 px-8 rounded-xl hover:bg-[#A00000] transition"
+            className="w-full bg-[#B31717] flex justify-between items-center text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
           >
-            カメラを起動する
+            <span>器具の検索</span>
+            <img src="/camera.svg" alt="camera" className="w-6 h-6" />
           </button>
         )}
 

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useState } from 'react';
 import Header from '@/feature/Header/Header';
 import { useRouter } from 'next/navigation';
+import Footer from '@/feature/Footer/Footer';
 
 export default function CameraPage() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -110,6 +111,7 @@ canvasRef.current.toBlob(async (blob) => {
 
         <canvas ref={canvasRef} className="hidden" />
       </div>
+      <Footer />
     </>
   );
 }

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 import React, { useRef, useState } from 'react';
 import Header from '@/feature/Header/Header';
+import { useRouter } from 'next/navigation';
 
 export default function CameraPage() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [streaming, setStreaming] = useState(false);
-
+  const router = useRouter();
   const handleStartCamera = async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ video: true });
@@ -52,7 +53,15 @@ export default function CameraPage() {
         }
 
         const result = await response.json();
-        alert(`マシン: ${result.machine_name}\nメニュー:\n${result.menus.map((m: any) => `・${m.name} (${m.part})`).join('\n')}`);
+
+        // ✅ 撮影結果と画像を result ページに渡して遷移
+        const imageUrl = URL.createObjectURL(blob);
+        const query = new URLSearchParams({
+          machine: result.machine_name,
+          menus: JSON.stringify(result.menus),
+          image: imageUrl,
+        });
+        router.push(`/result?${query.toString()}`);
       } catch (error) {
         console.error('判別失敗:', error);
         alert('マシンの判定に失敗しました');

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -80,38 +80,37 @@ canvasRef.current.toBlob(async (blob) => {
   };
 
   return (
-    <>
-      <Header />
-      <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white p-4 gap-4">
-        {!streaming && (
+  <div className="flex flex-col h-screen bg-black text-white">
+    <Header />
+    <div className="flex flex-col items-center justify-center flex-1 p-4 gap-4">
+      {!streaming && (
+        <button
+          onClick={handleStartCamera}
+          className="w-full bg-[#B31717] flex justify-between items-center text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
+        >
+          <span>器具の検索</span>
+          <img src="/camera.svg" alt="camera" className="w-6 h-6" />
+        </button>
+      )}
 
-          <button
-            onClick={handleStartCamera}
-            className="w-full bg-[#B31717] flex justify-between items-center text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
-          >
-            <span>器具の検索</span>
-            <img src="/camera.svg" alt="camera" className="w-6 h-6" />
-          </button>
-        )}
+      <video
+        ref={videoRef}
+        className={`${streaming ? 'block' : 'hidden'} rounded-lg`}
+        autoPlay
+      ></video>
 
-        <video
-          ref={videoRef}
-          className={`${streaming ? 'block' : 'hidden'} rounded-lg`}
-          autoPlay
-        ></video>
+      {streaming && (
+        <button
+          onClick={handleTakePhoto}
+          className="bg-[#B31717] text-white text-lg font-bold py-2 px-6 rounded hover:bg-[#A00000] transition"
+        >
+          撮影する
+        </button>
+      )}
 
-        {streaming && (
-          <button
-            onClick={handleTakePhoto}
-            className="bg-[#B31717] text-white text-lg font-bold py-2 px-6 rounded hover:bg-[#A00000] transition"
-          >
-            撮影する
-          </button>
-        )}
-
-        <canvas ref={canvasRef} className="hidden" />
-      </div>
-      <Footer />
-    </>
-  );
+      <canvas ref={canvasRef} className="hidden" />
+    </div>
+    <Footer />
+  </div>
+);
 }

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -21,19 +21,44 @@ export default function CameraPage() {
     }
   };
 
-  const handleTakePhoto = () => {
-    if (!videoRef.current || !canvasRef.current) return;
+  const handleTakePhoto = async () => {
+  if (!videoRef.current || !canvasRef.current) return;
 
-    const context = canvasRef.current.getContext('2d');
-    if (!context) return;
+  const context = canvasRef.current.getContext('2d');
+  if (!context) return;
 
-    const width = videoRef.current.videoWidth;
-    const height = videoRef.current.videoHeight;
+  const width = videoRef.current.videoWidth;
+  const height = videoRef.current.videoHeight;
 
-    canvasRef.current.width = width;
-    canvasRef.current.height = height;
-    context.drawImage(videoRef.current, 0, 0, width, height);
-  };
+  canvasRef.current.width = width;
+  canvasRef.current.height = height;
+  context.drawImage(videoRef.current, 0, 0, width, height);
+
+  // canvas → Blob に変換
+  canvasRef.current.toBlob(async (blob) => {
+    if (!blob) return;
+
+    const formData = new FormData();
+    formData.append('image', blob, 'photo.jpg');
+
+    try {
+      const response = await fetch('http://localhost:3000/api/v1/machines/identify', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error('サーバーエラー');
+      }
+
+      const result = await response.json();
+      alert(`マシン: ${result.machine_name}\nメニュー:\n${result.menus.map((m: any) => `・${m.name} (${m.part})`).join('\n')}`);
+    } catch (error) {
+      console.error('判別失敗:', error);
+      alert('マシンの判定に失敗しました');
+    }
+  }, 'image/jpeg');
+};
 
   return (
     <>

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -12,18 +12,29 @@ export default function ResultPage() {
     const saved = localStorage.getItem('capturedImage');
     if (saved) {
       setImage(saved);
-      localStorage.removeItem('capturedImage'); // 一度だけ使うなら削除
+      localStorage.removeItem('capturedImage');
     }
   }, []);
 
   return (
     <div className="min-h-screen bg-black text-white p-4">
       <h1 className="text-2xl font-bold mb-4">判定結果</h1>
-      {image && <img src={image} alt="撮影画像" className="w-full rounded-lg mb-4" />}
-      <p className="text-xl">マシン名: <strong>{machine}</strong></p>
-      <ul className="mt-2">
+
+      {image && (
+        <img src={image} alt="撮影画像" className="w-full rounded-lg mb-6" />
+      )}
+
+      <p className="text-xl mb-4">マシン名: <strong>{machine}</strong></p>
+
+      <h2 className="text-lg font-semibold mb-2">トレーニングメニュー:</h2>
+      <ul className="space-y-2">
         {menus.map((m: any, i: number) => (
-          <li key={i}>・{m.name}（{m.part}）</li>
+          <li key={i} className="bg-gray-800 p-3 rounded-lg">
+            <p className="text-base font-bold">{m.name}</p>
+            <p className="text-sm">部位: {m.part}</p>
+            <p className="text-sm">回数: {m.count}回 × {m.set_count}セット</p>
+            <p className="text-sm">重量: {m.weight}kg</p>
+          </li>
         ))}
       </ul>
     </div>

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -18,7 +18,7 @@ export default function ResultPage() {
 
   return (
     <div className="min-h-screen bg-black text-white p-4">
-      <h1 className="text-2xl font-bold mb-4">判定結果</h1>
+      <h1 className="text-2xl font-bold mb-4">マシン判定結果</h1>
 
       {image && (
         <img src={image} alt="撮影画像" className="w-full rounded-lg mb-6" />

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { FaPlay } from 'react-icons/fa';
+import Footer from '@/feature/Footer/Footer';
 
 export default function ResultPage() {
   const params = useSearchParams();
@@ -17,26 +19,40 @@ export default function ResultPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-black text-white p-4">
-      <h1 className="text-2xl font-bold mb-4">マシン判定結果</h1>
+    <div className="flex flex-col min-h-screen bg-black text-white">
+      <div className="flex-1 px-6 pt-6">
+        {/* 撮影画像 */}
+        {image && (
+          <img
+            src={image}
+            alt="撮影画像"
+            className="w-full rounded-lg mb-6 object-cover max-h-64"
+          />
+        )}
 
-      {image && (
-        <img src={image} alt="撮影画像" className="w-full rounded-lg mb-6" />
-      )}
+        {/* 器具名 */}
+        <h1 className="text-2xl font-bold mb-6">Machine Name:{machine}</h1>
 
-      <p className="text-xl mb-4">マシン名: <strong>{machine}</strong></p>
-
-      <h2 className="text-lg font-semibold mb-2">トレーニングメニュー:</h2>
-      <ul className="space-y-2">
-        {menus.map((m: any, i: number) => (
-          <li key={i} className="bg-gray-800 p-3 rounded-lg">
-            <p className="text-base font-bold">{m.name}</p>
-            <p className="text-sm">部位: {m.part}</p>
-            <p className="text-sm">回数: {m.count}回 × {m.set_count}セット</p>
-            <p className="text-sm">重量: {m.weight}kg</p>
-          </li>
-        ))}
-      </ul>
+        {/* Trainings */}
+        <h2 className="text-lg font-bold mb-2">Trainings:</h2>
+        <div className="flex flex-col gap-4">
+          {menus.map((menu: any, index: number) => (
+            <div
+              key={index}
+              className="bg-[#B31717] p-4 rounded-xl flex items-center justify-between"
+            >
+              <div>
+                <p className="font-bold">{menu.name}</p>
+                <p className="text-sm text-white/80">{menu.part}</p>
+              </div>
+              <FaPlay className="text-white text-xl" />
+            </div>
+          ))}
+        </div>
+      </div>
+      
+      {/* フッター */}
+      <Footer />
     </div>
   );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function ResultPage() {
+  const params = useSearchParams();
+  const machine = params.get('machine');
+  const menus = JSON.parse(params.get('menus') || '[]');
+  const [image, setImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('capturedImage');
+    if (saved) {
+      setImage(saved);
+      localStorage.removeItem('capturedImage'); // 一度だけ使うなら削除
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-black text-white p-4">
+      <h1 className="text-2xl font-bold mb-4">判定結果</h1>
+      {image && <img src={image} alt="撮影画像" className="w-full rounded-lg mb-4" />}
+      <p className="text-xl">マシン名: <strong>{machine}</strong></p>
+      <ul className="mt-2">
+        {menus.map((m: any, i: number) => (
+          <li key={i}>・{m.name}（{m.part}）</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary

カメラでジム機器を撮影し、判定されたマシン情報およびトレーニングメニューを結果ページで確認できる機能を実装。  
撮影画像は表示され、マシン名・部位・セット数・重量などをUIに合わせてリッチに表示。  
また、撮影後の判定が失敗した場合でも常に `/result` に遷移するよう安全な構成に。  
全体レイアウトを1画面内に収めるようにし、Footerを常に表示。

# Done

- 撮影した画像を base64 で localStorage に一時保存 → 結果ページで表示
- 撮影後、APIレスポンスに関係なく `/result` に遷移するロジックを追加
- `ResultPage` のUI構成を以下のようにリデザイン：
  - 撮影画像を上部に表示
  - 器具名を太く大きく表示
  - 各トレーニングを赤いカードで表示（name / part / count / set / weight）
  - Playボタンアイコンを右端に追加
  - `Start Training` ボタンを下部に追加
- 全体を `flex-col h-screen` に構成し、Footerが常に画面下部に収まるよう調整
- canvasの表示を `hidden` にし、デバッグ画像が出ないよう調整

# Notes

- 判定APIが `localhost:3000` で動作しているため、Next.jsが同ポートで競合しないよう要注意
- Tailwindの `max-h-64`, `object-cover` を使って撮影画像のはみ出しを防止
- trainingメニューの情報をリッチにしたが、Playボタンのアクションはまだ未設定（今後遷移等を検討）
- 今後撮影履歴一覧も追加できたらいいなー