### PR TITLE
Feature/add upload option

### DIFF
--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -74,7 +74,10 @@ export default function CameraPage() {
         body: formData,
       });
 
-      if (!response.ok) throw new Error('サーバーエラー');
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || 'サーバーエラー');
+      }
 
       const result: MachineResponse = await response.json();
       machine = result.machine_name || '不明';
@@ -82,8 +85,10 @@ export default function CameraPage() {
     } catch (error) {
       console.error('判別失敗:', error);
       setErrorMessage(
-        `画像の判別に失敗しました。\nエラー内容: ${error instanceof Error ? error.message : '不明なエラー'}`
+        `画像の判別に失敗しました。\nエラー内容: ${error instanceof Error ? error.message : '不明なエラー'
+        }`
       );
+      return; // エラーが起きたら画面遷移しない
     }
 
     const query = new URLSearchParams({

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -109,10 +109,9 @@ export default function CameraPage() {
           <>
             <button
               onClick={handleStartCamera}
-              className="w-full bg-[#B31717] flex justify-center items-center text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
+              className="w-full bg-[#B31717] flex justify-center items-center gap-2 text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
             >
-              <span>器具を撮影する
-              </span>
+              <span>器具を撮影する</span>
               <img src="/camera.svg" alt="camera" className="w-6 h-6" />
             </button>
 

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -10,6 +10,7 @@ export default function CameraPage() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [streaming, setStreaming] = useState(false);
   const router = useRouter();
+  const [errorMessage, setErrorMessage] = useState('');
 
   const handleStartCamera = async () => {
     try {
@@ -20,7 +21,7 @@ export default function CameraPage() {
         setStreaming(true);
       }
     } catch (err) {
-      alert('カメラを起動できませんでした。許可が必要です。');
+      setErrorMessage('カメラを起動できませんでした。許可が必要です。');
       console.error(err);
     }
   };
@@ -80,7 +81,7 @@ export default function CameraPage() {
       menus = result.menus || [];
     } catch (error) {
       console.error('判別失敗:', error);
-      alert(
+      setErrorMessage(
         `画像の判別に失敗しました。\nエラー内容: ${error instanceof Error ? error.message : '不明なエラー'}`
       );
     }

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -45,7 +45,6 @@ export default function CameraPage() {
       const reader = new FileReader();
       reader.onloadend = async () => {
         localStorage.setItem('capturedImage', reader.result as string);
-
         await identifyMachine(blob);
       };
       reader.readAsDataURL(blob);
@@ -68,7 +67,8 @@ export default function CameraPage() {
 
     try {
       const formData = new FormData();
-      formData.append('image', imageFile);
+      const filename = imageFile instanceof File ? imageFile.name : 'image.jpg';
+      formData.append('image', imageFile, filename); 
 
       const response = await fetch('http://localhost:3000/api/v1/machines/identify', {
         method: 'POST',
@@ -86,10 +86,9 @@ export default function CameraPage() {
     } catch (error) {
       console.error('判別失敗:', error);
       setErrorMessage(
-        `画像の判別に失敗しました。\nエラー内容: ${error instanceof Error ? error.message : '不明なエラー'
-        }`
+        `画像の判別に失敗しました。\nエラー内容: ${error instanceof Error ? error.message : '不明なエラー'}`
       );
-      return; // エラーが起きたら画面遷移しない
+      return;
     }
 
     const query = new URLSearchParams({

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -4,6 +4,7 @@ import Header from '@/feature/Header/Header';
 import { useRouter } from 'next/navigation';
 import Footer from '@/feature/Footer/Footer';
 import { TrainingMenu, MachineResponse } from '@/types/machine';
+import Image from 'next/image';
 
 export default function CameraPage() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -118,7 +119,7 @@ export default function CameraPage() {
               className="w-full bg-[#B31717] flex justify-center items-center gap-2 text-lg font-bold py-4 px-6 rounded-xl hover:bg-[#A00000] transition"
             >
               <span>器具を撮影する</span>
-              <img src="/camera.svg" alt="camera" className="w-6 h-6" />
+              <Image src="/camera.svg" alt="camera icon" width={24} height={24} />
             </button>
 
             <label className="w-full">

--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -151,6 +151,12 @@ export default function CameraPage() {
         )}
 
         <canvas ref={canvasRef} className="hidden" />
+
+        {errorMessage && (
+          <div className="text-white font-semibold text-center mt-4 whitespace-pre-line">
+            {errorMessage}
+          </div>
+        )}
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
# Summary

ジム機器をカメラで撮影するだけでなく、端末内の画像をアップロードして判定できる機能を追加。  
これにより、カメラ非対応環境や過去に撮影した画像からもマシンを判別可能に。

# Done

- 撮影機能の下に「ギャラリーから画像を選ぶ」ボタンを追加
- `<input type="file">` により画像選択 → base64形式で `localStorage` に保存
- 選択画像を `FormData` に含めて `/api/v1/machines/identify` にPOST送信
- 判定結果（machine_name・menus）に関係なく `/result` に遷移
- ボタンとアイコンの間に `gap-2` を設定してUI調整

# Notes

- 撮影・アップロードどちらの画像も `capturedImage` キーで保存
- 今後、アップロード履歴一覧などの機能追加も検討余地あり

@github-copilot please review this pull request and suggest improvements.