### PR TITLE
Fix: handle array response from machine identify API

### DIFF
--- a/src/app/camera/page.tsx
+++ b/src/app/camera/page.tsx
@@ -80,9 +80,12 @@ export default function CameraPage() {
         throw new Error(errorData.message || 'サーバーエラー');
       }
 
-      const result: MachineResponse = await response.json();
-      machine = result.machine_name || '不明';
-      menus = result.menus || [];
+      const result: MachineResponse[] = await response.json();
+      if (result.length === 0) {
+        throw new Error('画像から器具を判別できませんでした。');
+      }
+      machine = result[0].machine_name || '不明';
+      menus = result[0].menus || [];
     } catch (error) {
       console.error('判別失敗:', error);
       setErrorMessage(


### PR DESCRIPTION
##  Summary

マシン判定のレスポンスが複数で帰ってくるので一番初めの見返すように変更

---

## Done

バックエンドレスポンスに適応した形に変更

---

## Notes


- 現時点では判定結果配列の**先頭1件のみ使用中**。複数候補表示にも拡張可能